### PR TITLE
Flatten the crate's interface, to leak less internal structure

### DIFF
--- a/benches/dfs_overhead.rs
+++ b/benches/dfs_overhead.rs
@@ -11,7 +11,7 @@ use std::{
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use superposition::{dfs::Dfs, kripke_structure::KripkeStructure};
+use superposition::{dfs::Dfs, KripkeStructure};
 
 #[derive(Default, Clone)]
 struct MyBench {

--- a/src/dfs.rs
+++ b/src/dfs.rs
@@ -1,5 +1,8 @@
+//! Depth-first search of a [KripkeStructure].
+
 use crate::KripkeStructure;
 
+/// Errors that may occur during DFS traversal.
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum DfsError {
     #[error("depth exceeded max depth {0}")]
@@ -142,7 +145,7 @@ where
     }
 }
 
-/// Run depth-first-search over a KripkeStructure.
+/// Run depth-first-search over a [KripkeStructure].
 pub fn dfs<KS>(ks: KS, max_depth: Option<usize>) -> Result<(), DfsError>
 where
     KS: KripkeStructure + Copy,

--- a/src/futures/controller.rs
+++ b/src/futures/controller.rs
@@ -1,3 +1,5 @@
+//! Defines the Controller trait that provides user hooks.
+
 use super::executor::Executor;
 
 /// Events used to track behavior and manage state during a simulation.

--- a/src/futures/executor.rs
+++ b/src/futures/executor.rs
@@ -48,7 +48,7 @@ type Runnable = async_task::Task<TaskId>;
 ///
 /// Tasks that panic get immediately canceled. Awaiting a canceled task also causes a panic.
 ///
-/// If a task panics, the panic will be thrown by the [`Ticker::tick()`] invocation that polled it.
+/// If a task panics, the panic will be thrown by the Ticker::tick() invocation that polled it.
 #[must_use = "tasks get canceled when dropped, use `.detach()` to run them in the background"]
 #[derive(Debug)]
 pub struct Task<T>(Option<async_task::JoinHandle<T, TaskId>>);

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -1,11 +1,16 @@
-pub mod controller;
-pub mod executor;
+//! Modeling and execution utilities.
+
+mod controller;
+pub use controller::Controller;
+
+mod executor;
+pub use executor::{Executor, Task};
+
 pub mod hilberts_epsilon;
 pub mod on_ready_fn;
-pub mod simulator;
+
+mod simulator;
+pub use simulator::Simulator;
+
 pub mod sync;
 pub mod utils;
-
-pub use controller::Controller;
-pub use executor::Executor;
-pub use simulator::Simulator;

--- a/src/kripke_structure.rs
+++ b/src/kripke_structure.rs
@@ -1,17 +1,19 @@
-/// An implicit Kripke Structure that defines a state space.
+//! Defines the Kripke structure.
+
+/// An implicit [Kripke structure](https://en.wikipedia.org/wiki/Kripke_structure)
+/// that defines a state space.
 ///
-/// Unlike a traditional Kripke Structure, this:
+/// Unlike a traditional Kripke structure, this:
+///   1. prohibits the existence of multiple start states,
+///   2. permits the existence of infinite sets of states (path depth), and
+///   3. permits the existence of infinite sets of successors (path width).
 ///
-///   1) prohibits the existence of multiple start states,
-///
-///   2) permits the existence of infinite sets of states (path depth), and
-///
-///   3) permits the existence of infinite sets of successsors (path width).
 pub trait KripkeStructure {
     type Label: Copy;
     type LabelIterator: Iterator<Item = Self::Label> + Clone;
 
     /// Make a transition in the state space.
+    ///
     /// The label can be assumed to come from the previous call to successors.
     fn transition(self, label: Self::Label);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+//! Verifies concurrent behavior of real code using finite-space model checking.
+
 pub mod dfs;
 pub mod futures;
-pub mod kripke_structure;
 
+mod kripke_structure;
 pub use kripke_structure::KripkeStructure;


### PR DESCRIPTION
This patch slightly modifies how items are exported so that they present a cleaner interface to a user.

The changes are slight. For example, they will see just `KripkeStructure` instead of `kripke_structure::KripkeStructure`, and they will see just `futures::hilbert_epsilon` instead of `futures::hilbert_epsilon::hilbert_epsilon`.