### PR TITLE
use our own Task type in the executor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "Verify concurrent behavior of real code using finite-space model 
 publish = false
 
 [dependencies]
-async-task = "3"
 concurrent-queue = "1"
 futures-intrusive = { version = "0.3", default-features = false, features = [ "alloc" ] }
 futures-lite = "0.1"
@@ -16,6 +15,7 @@ itertools = "0.9"
 pin-project-lite = "0.1"
 spin = "0.5"
 thiserror = "1"
+waker-fn = "1"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/benches/futures_executor.rs
+++ b/benches/futures_executor.rs
@@ -15,12 +15,11 @@ fn f(b: &mut criterion::Bencher, n_spawns: usize, n_yields_explicit: usize) {
 
         for _ in 0..iters {
             for _ in 0..n_spawns {
-                ex.spawn(async move {
+                ex.spawn_detach(async move {
                     for _ in 0..n_yields_explicit {
                         yield_now().await;
                     }
-                })
-                .detach();
+                });
             }
             ex.reset();
         }

--- a/benches/futures_simulator_dfs.rs
+++ b/benches/futures_simulator_dfs.rs
@@ -29,12 +29,11 @@ impl Controller for MyBench {
     #[inline]
     fn on_restart(self, ex: &Executor) -> Self {
         for _ in 0..self.n_processes {
-            ex.spawn(async move {
+            ex.spawn_detach(async move {
                 for _ in 0..self.n_yields_explicit {
                     yield_now().await;
                 }
-            })
-            .detach();
+            });
         }
         self
     }

--- a/src/futures/hilberts_epsilon.rs
+++ b/src/futures/hilberts_epsilon.rs
@@ -35,13 +35,12 @@ where
     let flag = Arc::new(AtomicBool::new(false));
 
     // Spawn the background process that may eventually toggle the slot to true.
-    ex.spawn({
+    ex.spawn_detach({
         let flag = flag.clone();
         async move {
             flag.store(true, Ordering::SeqCst);
         }
-    })
-    .detach();
+    });
 
     // Iterate through the choices, returning the first element that is seen after the flag is set
     // to true. If the flag is never set to true, return the last element in the iterator.


### PR DESCRIPTION
Appears to reduce latency in the executor by 50%, but does not affect DFS simulation with the executor that much.