### PR TITLE
Fix benches and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ description = "Verify concurrent behavior of real code using finite-space model 
 publish = false
 
 [dependencies]
-futures-intrusive = { version = "0.3", default-features = false, features = [ "alloc" ] }
-futures-lite = "0.1"
+futures-intrusive = { version = "0.4", default-features = false, features = [ "alloc", "std" ] }
+futures-lite = "1.11"
 futures-util = "0.3"
-pin-project-lite = "0.1"
+pin-project-lite = "0.2"
 thiserror = "1"
 
 [dev-dependencies]

--- a/benches/futures_simulator_dfs.rs
+++ b/benches/futures_simulator_dfs.rs
@@ -7,7 +7,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use superposition::{
     dfs::Dfs,
-    futures::{utils::yield_now, Controller, Executor, Simulator, Spawner},
+    futures::{utils::yield_now, ChoiceTaken, Controller, Executor, Simulator, Spawner},
 };
 
 #[derive(Default, Copy, Clone)]
@@ -40,7 +40,7 @@ impl Controller for MyBench {
         }
     }
     #[inline]
-    fn on_transition(&mut self) {}
+    fn on_transition(&mut self, _: ChoiceTaken) {}
     #[inline]
     fn on_end_of_trajectory(&mut self, _ex: &Executor) {}
 }

--- a/tests/futures_simulator.rs
+++ b/tests/futures_simulator.rs
@@ -54,7 +54,7 @@ fn stream_iteration() {
     struct MyTest {
         num_trajectories: usize,
         values: Rc<RefCell<Vec<u8>>>,
-    };
+    }
     impl Controller for MyTest {
         fn on_restart(&mut self, spawner: &Spawner) {
             let mut s = stream::iter(vec![1, 2, 3]);
@@ -95,7 +95,7 @@ fn detects_race_condition() {
         b: Rc<RefCell<isize>>,
         num_failed: usize,
         num_trajectories: usize,
-    };
+    }
 
     impl Controller for MyTest {
         #[inline]
@@ -243,7 +243,7 @@ fn multiple_hilberts_epsilons_do_not_explode_state_space() {
     struct MyTest {
         tuples: Rc<RefCell<std::collections::BTreeSet<(u8, i8, usize)>>>,
         num_trajectories: usize,
-    };
+    }
 
     impl Controller for MyTest {
         #[inline]
@@ -295,7 +295,7 @@ fn nested_hilberts_epsilons_increase_state_space_only_minimally() {
     #[derive(Default)]
     struct MyTest {
         num_trajectories: usize,
-    };
+    }
 
     impl Controller for MyTest {
         #[inline]
@@ -353,7 +353,7 @@ fn choice_stream_validity() {
 
         /// The choice made by the current trajectory, collected at the end.
         this_choice: Rc<RefCell<usize>>,
-    };
+    }
 
     impl Controller for TestState {
         fn on_restart(&mut self, spawner: &Spawner) {


### PR DESCRIPTION
The `futures_intrusive` crate now only provides the `Mutex` under the `std` feature.